### PR TITLE
Introduce named arguments for LAMBDA_ARGS_ADD

### DIFF
--- a/examples/arguments.sh
+++ b/examples/arguments.sh
@@ -1,0 +1,19 @@
+ROOT_DIR=$(git rev-parse --show-toplevel)
+pushd "$ROOT_DIR" > /dev/null
+
+source "$ROOT_DIR/lambda.sh"
+
+LAMBDA_ARGS_ADD \
+    --name "first_arg" --description "The first argument" --default "1"
+LAMBDA_ARGS_ADD \
+    --name "second_arg" --description "The second argument" --default "2"
+
+LAMBDA_ARGS_ADD --description "Do something" --name "required" --default "s"
+
+LAMBDA_ARGS_COMPILE "$@"
+
+LAMBDA_LOG_INFO "$LAMBDA_first_arg"
+LAMBDA_LOG_INFO "$LAMBDA_second_arg"
+LAMBDA_LOG_INFO "$LAMBDA_required"
+
+popd > /dev/null # $ROOT_DIR

--- a/examples/arguments.sh
+++ b/examples/arguments.sh
@@ -8,7 +8,7 @@ LAMBDA_ARGS_ADD \
 LAMBDA_ARGS_ADD \
     --name "second_arg" --description "The second argument" --default "2"
 
-LAMBDA_ARGS_ADD --description "Do something" --name "required" --default "s"
+LAMBDA_ARGS_ADD --description "Do something" --name "required"
 
 LAMBDA_ARGS_COMPILE "$@"
 

--- a/examples/logging.sh
+++ b/examples/logging.sh
@@ -9,4 +9,4 @@ LAMBDA_LOG_TRACE "This is a trace."
 LAMBDA_LOG_ERROR "This is an error."
 LAMBDA_LOG_FATAL "This is a fatal message."
 
-popd  # ROOT_DIR
+popd  # $ROOT_DIR

--- a/lambda.sh
+++ b/lambda.sh
@@ -221,7 +221,7 @@ LAMBDA_ARGS_ADD() {
     __LAMBDA_ARGS_PARSE \
         default \
         "The default value of the argument (No value implies it's required)" \
-        "__LAMBDA_NOT_REQUIRED"
+        "__LAMBDA_ARGS_REQUIRED"
 
 
     LAMBDA_ARGS_COMPILE "--internal_lambda_args" "$@"
@@ -248,17 +248,18 @@ __LAMBDA_ARGS_SHOW_HELP_STRING() {
   printf "\n%-20s %-20s %-20s %-20s\n" "Arg" "Default value" "Required" "Description"
   __LAMBDA_TERM_CLEAR_ATTRIBUTES
 
-  for ((i=0; i<$S; i++)); do
+  for ((i=0; i<"$__LAMBDA_ARGS_COUNT"; i++)); do
     IFS=':' read -ra ARG_MAP <<< "${__LAMBDA_ARGS_REGISTERED_MAP[${i}]}"
 
     ARG_NAME="${ARG_MAP[0]}"
     ARG_INDEX="${ARG_MAP[1]}"
     ARG_DEFAULT_VALUE="${__LAMBDA_ARGS_DEFAULT_VALUES[${ARG_INDEX}]}"
     ARG_DESCRIPTION="${__LAMBDA_ARG_DESCRIPTIONS[${ARG_INDEX}]}"
-    ARG_REQUIRED="False"
+    ARG_REQUIRED="false"
 
     if [ -z "${__LAMBDA_ARGS_DEFAULT_VALUES[${ARG_INDEX}]}" ]; then
-      ARG_REQUIRED="True"
+      ARG_REQUIRED="true"
+      ARG_DEFAULT_VALUE=""
     fi
 
     printf "%-20s %-20s %-20s %-20s\n" \
@@ -356,7 +357,7 @@ LAMBDA_ARGS_COMPILE() {
       if [ -z "${ARG_DEFAULT_VALUES[${ARG_INDEX}]}" ]; then
         LAMBDA_LOG_FATAL \
           "--$ARG_NAME has no default value and therefore cannot be left empty."
-      elif [ "${ARG_DEFAULT_VALUES[${ARG_INDEX}]}" = "__LAMBDA_ARG_REQUIRED" ]; then
+      elif [ "${ARG_DEFAULT_VALUES[${ARG_INDEX}]}" = "__LAMBDA_ARGS_REQUIRED" ]; then
         DEFAULT_VALUE=""
         export "LAMBDA_${ARG_NAME//-/_}"="$DEFAULT_VALUE"
       else
@@ -372,6 +373,12 @@ LAMBDA_ARGS_COMPILE() {
     export __LAMBDA_ARGS_ADD_HELP_STRINGS=()
     export __LAMBDA_ARGS_ADD_IS_SET=()
     export __LAMBDA_ARGS_ADD_COUNT=0
+  else
+    export __LAMBDA_ARGS_REGISTERED_MAP=()
+    export __LAMBDA_ARGS_DEFAULT_VALUES=()
+    export __LAMBDA_ARGS_HELP_STRINGS=()
+    export __LAMBDA_ARGS_IS_SET=()
+    export __LAMBDA_ARGS_COUNT=0
   fi
 }
 

--- a/lambda.sh
+++ b/lambda.sh
@@ -240,7 +240,6 @@ LAMBDA_ARGS_ADD() {
     unset -v LAMBDA_name
     unset -v LAMBDA_description
     unset -v LAMBDA_default
-    unset -v LAMBDA_required
 }
 
 __LAMBDA_ARGS_SHOW_HELP_STRING() {


### PR DESCRIPTION
This allows you to use flags position independent flags for setting up arguments for bash scripts and functions. `LAMBDA_ARGS_COMPILE` also needs to be executed immediately after the last flag is setup in order to ensure that flags are properly parsed.